### PR TITLE
Update package.json - require node 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,8 +21,7 @@
     "url": "https://github.com/crycode-de/ioBroker.discord"
   },
   "engines": {
-    "node": ">=16.9.0",
-    "npm": ">=7.0.0"
+    "node": ">=18"
   },
   "dependencies": {
     "@iobroker/adapter-core": "^3.0.6",


### PR DESCRIPTION
As this adapter is o longer tested with node 16 (which is OK) and nod 16 is EOL since some time please merge this PR to require node 18 for next minor release.